### PR TITLE
Fix most tests and nesting structure of form_components

### DIFF
--- a/formiodata/builder.py
+++ b/formiodata/builder.py
@@ -64,7 +64,7 @@ class Builder:
                 component_obj = self.get_component_object(component)
                 # start and traverse from toplevel
                 self.components[component_obj.key] = component_obj
-                component_obj.load(None, None)
+                component_obj.load(self, parent=None, data=None)
 
     def get_component_object(self, component):
         """

--- a/formiodata/form.py
+++ b/formiodata/form.py
@@ -51,12 +51,14 @@ class Form:
         self.builder = Builder(self.builder_schema_json, self.lang)
 
     def load_components(self):
+        # TODO: Make recursive(?)
         for key, component in self.builder.form_components.items():
             # Rather lazy check, but sane.
             # if not self.form.get(key):
             #     continue
             # replaced with default value and fast
             raw_value = self.form.get(key, component.defaultValue)
+            component.component_owner = self.builder
             component.value = raw_value
             component.raw_value = raw_value
             self.components[key] = component
@@ -72,23 +74,21 @@ class FormRenderer:
     def __init__(self, form):
         self.form = form
         self.builder = form.builder
-        self.components = OrderedDict()
-        self.component_ids = {}
         self.load_components()
 
     def load_components(self):
         """ Loads the components (tree) to render, with values
         (data) and obtaining the tree by creating all sub-components
         e.g. in layout and datagrid. """
-        for component in self.builder.raw_components:
-            # Only determine and load class if component type.
-            if 'type' in component:
-                builder_component_obj = self.builder.component_ids[component['id']]
-                # New object, don't affect the Builder component
-                component_obj = self.builder.get_component_object(builder_component_obj.raw)
-                component_obj.load(None, self.form.form)
-                self.components[component_obj.key] = component_obj
+        self.builder.load_components()
 
+    @property
+    def components(self):
+        return self.builder.components
+
+    @property
+    def component_ids(self):
+        return self.builder.component_ids
 
 class FormData:
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -15,6 +15,7 @@ class BuilderTestCase(CommonTestCase):
 
     def test_components(self):
         builder = self._builder()
-        keys = ('firstName', 'email', 'lastName', 'phoneNumber', 'survey', 'signature', 'submit')
+        # NOTE: submit button is not considered a form component
+        keys = ('firstName', 'email', 'lastName', 'phoneNumber', 'survey', 'signature')
         for k in keys:
             self.assertIn(k, builder.form_components.keys())

--- a/tests/test_component_datagrid.py
+++ b/tests/test_component_datagrid.py
@@ -15,8 +15,6 @@ class datagridComponentTestCase(ComponentTestCase):
         # Not TextfieldComponent
         email = self.builder.form_components['email']
         self.assertNotIsInstance(email, datagridComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, datagridComponent)
 
     def test_get_key(self):
         dataGrid = self.builder.components['dataGrid']

--- a/tests/test_component_datetime.py
+++ b/tests/test_component_datetime.py
@@ -20,8 +20,6 @@ class datetimeComponentTestCase(ComponentTestCase):
         # Not datetimeComponent
         email = self.builder.form_components['email']
         self.assertNotIsInstance(email, datetimeComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, datetimeComponent)
 
     def test_get_key(self):
         birthdate = self.builder.form_components['birthdate']

--- a/tests/test_component_email.py
+++ b/tests/test_component_email.py
@@ -15,8 +15,6 @@ class emailComponentTestCase(ComponentTestCase):
         # Not EmailComponent
         firstName = self.builder.form_components['firstName']
         self.assertNotIsInstance(firstName, emailComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, emailComponent)
 
     def test_get_key(self):
        email = self.builder.form_components['email']

--- a/tests/test_component_file_storage_base64.py
+++ b/tests/test_component_file_storage_base64.py
@@ -20,8 +20,6 @@ class fileComponentStorageBase64TestCase(ComponentTestCase):
         # Not fileComponent
         email = self.builder.form_components['email']
         self.assertNotIsInstance(email, fileComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, fileComponent)
 
     def test_get_key(self):
         uploadBase64 = self.builder.form_components['uploadBase64']

--- a/tests/test_component_file_storage_url.py
+++ b/tests/test_component_file_storage_url.py
@@ -21,8 +21,6 @@ class fileComponentStorageUrlTestCase(ComponentTestCase):
         # Not fileComponent
         email = self.builder.form_components['email']
         self.assertNotIsInstance(email, fileComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, fileComponent)
 
     def test_get_key(self):
         uploadUrl = self.builder.form_components['uploadUrl']

--- a/tests/test_component_panel.py
+++ b/tests/test_component_panel.py
@@ -15,8 +15,6 @@ class panelComponentTestCase(ComponentTestCase):
         # Not TextfieldComponent
         email = self.builder.form_components['email']
         self.assertNotIsInstance(email, panelComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, panelComponent)
 
     def test_get_key(self):
         panel = self.builder.components['panel']

--- a/tests/test_component_phoneNumber.py
+++ b/tests/test_component_phoneNumber.py
@@ -15,8 +15,6 @@ class PhoneNumberComponentTestCase(ComponentTestCase):
         # Not phoneNumberComponent
         firstName = self.builder.form_components['firstName']
         self.assertNotIsInstance(firstName, phoneNumberComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, phoneNumberComponent)
 
     def test_get_key(self):
         phoneNumber = self.builder.form_components['phoneNumber']

--- a/tests/test_component_radio.py
+++ b/tests/test_component_radio.py
@@ -14,8 +14,6 @@ class radioComponentTestCase(ComponentTestCase):
         # Not radioComponent
         email = self.builder.form_components['email']
         self.assertNotIsInstance(email, radioComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, radioComponent)
 
     def test_get_key(self):
         cd = self.builder.form_components['cardinalDirection']

--- a/tests/test_component_select_multiple.py
+++ b/tests/test_component_select_multiple.py
@@ -15,8 +15,6 @@ class selectMultipleComponentTestCase(ComponentTestCase):
         # Not selectComponent
         email = self.builder.form_components['email']
         self.assertNotIsInstance(email, selectComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, selectComponent)
 
     def test_get_key(self):
         food = self.builder.form_components['favouriteFood']

--- a/tests/test_component_select_one.py
+++ b/tests/test_component_select_one.py
@@ -15,8 +15,6 @@ class selectOneComponentTestCase(ComponentTestCase):
         # Not selectComponent
         email = self.builder.form_components['email']
         self.assertNotIsInstance(email, selectComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, selectComponent)
 
     def test_get_key(self):
         season = self.builder.form_components['favouriteSeason']

--- a/tests/test_component_survey.py
+++ b/tests/test_component_survey.py
@@ -15,8 +15,6 @@ class surveyComponentTestCase(ComponentTestCase):
         # Not surveyComponent
         firstName = self.builder.form_components['firstName']
         self.assertNotIsInstance(firstName, surveyComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, surveyComponent)
 
     def test_get_key(self):
         survey = self.builder.form_components['survey']

--- a/tests/test_component_textfield.py
+++ b/tests/test_component_textfield.py
@@ -18,8 +18,6 @@ class textfieldComponentTestCase(ComponentTestCase):
         # Not TextfieldComponent
         email = self.builder.form_components['email']
         self.assertNotIsInstance(email, textfieldComponent)
-        submit = self.builder.form_components['submit']
-        self.assertNotIsInstance(submit, textfieldComponent)
 
     def test_get_key(self):
         firstName = self.builder.form_components['firstName']


### PR DESCRIPTION
The `form_components` are now maintained on either the Builder class (as before), or on the deepest dataGrid class under which the component belongs.

See the commit messages for more information.