### PR TITLE
Fix JSON conditional logic to work properly on global data (#14)

### DIFF
--- a/formiodata/components.py
+++ b/formiodata/components.py
@@ -26,8 +26,13 @@ class Component:
         # XXX uuid to ensure (hope this won't break anything)
         self.id = self.raw.get('id', str(uuid.uuid4()))
 
-        # submission {key: value, ...}
+        # submission at this level {key: value, ...}
+        # This includes a pseudo 'value' key which always encodes the current
+        # component's value.  NOTE: This should be refactored away for conditionals
+        # to work 100% correct when there's another element with a "value" key.
         self.form = {}
+        # Full raw data from the root on up {key: value, ...}
+        self._all_data = {}
 
         # i18n (language, translations)
         self.language = kwargs.get('language', 'en')
@@ -38,12 +43,13 @@ class Component:
         self.html_component = ""
         self.defaultValue = self.raw.get('defaultValue')
 
-    def load(self, component_owner, parent=None, data=None):
+    def load(self, component_owner, parent=None, data=None, all_data=None):
         self.component_owner = component_owner
 
         if parent:
             self.parent = parent
 
+        self._all_data = all_data
         self.load_data(data)
 
         self.builder.component_ids[self.id] = self
@@ -66,7 +72,7 @@ class Component:
             # Only determine and load class if component type.
             if 'type' in component:
                 component_obj = self.builder.get_component_object(component)
-                component_obj.load(self.child_component_owner, parent=self, data=data)
+                component_obj.load(self.child_component_owner, parent=self, data=data, all_data=self._all_data)
 
         # TODO: This code is iffy and tries to be generic for unknown components.
         # Maybe only call this (and the above) if not an input component?
@@ -77,7 +83,7 @@ class Component:
                     if 'components' in v:
                         for v_component in v['components']:
                             v_component_obj = self.builder.get_component_object(v_component)
-                            v_component_obj.load(self.child_component_owner, parent=self, data=data)
+                            v_component_obj.load(self.child_component_owner, parent=self, data=data, all_data=self._all_data)
                     elif isinstance(v, list):
                         # table component etc. which holds even deeper lists with components
                         for list_v in v:
@@ -86,7 +92,7 @@ class Component:
                                     if list_v_component.get('type'):
                                         list_v_component_obj = self.builder.get_component_object(list_v_component)
                                         if list_v_component_obj.id not in self.builder.component_ids:
-                                            list_v_component_obj.load(self.child_component_owner, parent=self, data=data)
+                                            list_v_component_obj.load(self.child_component_owner, parent=self, data=data, all_data=self._all_data)
 
     @property
     def id(self):
@@ -208,7 +214,7 @@ class Component:
                 # Optional package
                 try:
                     from json_logic import jsonLogic
-                    context = {'data': self.component_owner.form}
+                    context = {'data': self._all_data}
                     try:
                         context['row'] = self.component_owner.row
                     except AttributeError:
@@ -871,7 +877,7 @@ class datagridComponent(Component):
             # Only determine and load class if component type.
             if 'type' in component:
                 component_obj = parent.builder.get_component_object(component)
-                component_obj.load(component_owner=parent, parent=parent, data=data)
+                component_obj.load(component_owner=parent, parent=parent, data=data, all_data=self._all_data)
                 parent.components[component_obj.key] = component_obj
 
     def load_data(self, data):

--- a/formiodata/form.py
+++ b/formiodata/form.py
@@ -60,7 +60,7 @@ class Form:
         for key, component in self.builder.components.items():
             # New object, don't affect the Builder component
             component_obj = self.builder.get_component_object(component.raw)
-            component_obj.load(component_owner=self, parent=None, data=self.form)
+            component_obj.load(component_owner=self, parent=None, data=self.form, all_data=self.form)
             self.components[key] = component_obj
             self.component_ids[component_obj.id] = component_obj
 

--- a/tests/data/test_conditional_visibility_nested_json_logic_builder.json
+++ b/tests/data/test_conditional_visibility_nested_json_logic_builder.json
@@ -1283,6 +1283,111 @@
                                             "placeholder": "",
                                             "labelPosition": "top",
                                             "label": "Secret"
+                                        },
+                                        {
+                                            "id": "e1ymnj3",
+                                            "inputType": "text",
+                                            "dataGridLabel": false,
+                                            "refreshOn": "",
+                                            "hideOnChildrenHidden": false,
+                                            "input": true,
+                                            "type": "textfield",
+                                            "overlay": {
+                                                "height": "",
+                                                "width": "",
+                                                "top": "",
+                                                "left": "",
+                                                "page": "",
+                                                "style": ""
+                                            },
+                                            "attributes": {
+                                            },
+                                            "logic": [],
+                                            "customConditional": "",
+                                            "conditional": {
+                                                "json": {
+                                                    "and": [
+                                                        {
+                                                            "===": [
+                                                                {
+                                                                    "var": "data.username"
+                                                                },
+                                                                "user"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "===": [
+                                                                {
+                                                                    "var": "data.password"
+                                                                },
+                                                                "secret"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "eq": "",
+                                                "when": null,
+                                                "show": null
+                                            },
+                                            "properties": {
+                                            },
+                                            "tags": [],
+                                            "key": "globalSecret",
+                                            "errorLabel": "",
+                                            "unique": false,
+                                            "validate": {
+                                                "unique": false,
+                                                "multiple": false,
+                                                "strictDateValidation": false,
+                                                "maxLength": "",
+                                                "minLength": "",
+                                                "json": "",
+                                                "customPrivate": false,
+                                                "custom": "",
+                                                "customMessage": "",
+                                                "pattern": "",
+                                                "required": false
+                                            },
+                                            "validateOn": "change",
+                                            "allowCalculateOverride": false,
+                                            "calculateServer": false,
+                                            "calculateValue": "",
+                                            "customDefaultValue": "",
+                                            "clearOnHide": true,
+                                            "redrawOn": "",
+                                            "encrypted": false,
+                                            "case": "",
+                                            "dbIndex": false,
+                                            "protected": false,
+                                            "inputFormat": "plain",
+                                            "persistent": true,
+                                            "defaultValue": "Another secret message",
+                                            "multiple": false,
+                                            "modalEdit": false,
+                                            "tableView": true,
+                                            "disabled": false,
+                                            "spellcheck": true,
+                                            "autofocus": false,
+                                            "mask": false,
+                                            "showCharCount": false,
+                                            "showWordCount": false,
+                                            "hideLabel": false,
+                                            "hidden": false,
+                                            "autocomplete": "",
+                                            "tabindex": "",
+                                            "customClass": "",
+                                            "allowMultipleMasks": false,
+                                            "inputMask": "",
+                                            "widget": {
+                                                "type": "input"
+                                            },
+                                            "suffix": "",
+                                            "prefix": "",
+                                            "tooltip": "",
+                                            "description": "",
+                                            "placeholder": "",
+                                            "labelPosition": "top",
+                                            "label": "Global Secret"
                                         }
                                     ]
                                 }

--- a/tests/data/test_conditional_visibility_nested_json_logic_hide_global_secret_only.json
+++ b/tests/data/test_conditional_visibility_nested_json_logic_hide_global_secret_only.json
@@ -1,6 +1,6 @@
 {
-    "username": "user",
-    "password": "secret",
+    "username": "wrong",
+    "password": "incorrect",
     "username1": "user",
     "password1": "secret",
     "username2": "user",
@@ -9,20 +9,17 @@
         {
             "username3": "user",
             "password3": "secret",
-            "secret3": "Secret message",
-            "globalSecret": "Another secret message"
+            "secret3": "Secret message"
         },
         {
             "username3": "user",
             "password3": "secret",
-            "secret3": "Secret message",
-            "globalSecret": "Another secret message"
+            "secret3": "Secret message"
         }
     ],
-    "password3": "",
-    "username3": "",
-    "secret": "Secret message",
     "secret1": "Secret message",
     "secret2": "Secret message",
-    "submit": true
+    "submit": true,
+    "password3": "",
+    "username3": ""
 }

--- a/tests/data/test_conditional_visibility_nested_json_logic_show_global_secret_only.json
+++ b/tests/data/test_conditional_visibility_nested_json_logic_show_global_secret_only.json
@@ -1,0 +1,25 @@
+{
+    "username": "user",
+    "password": "secret",
+    "secret": "Secret message",
+    "username1": "wrong",
+    "password1": "incorrect",
+    "username2": "wrong",
+    "password2": "incorrect",
+    "dataGrid": [
+        {
+            "username3": "wrong",
+            "password3": "incorrect",
+            "globalSecret": "Another secret message"
+        },
+        {
+            "username3": "wrong",
+            "password3": "incorrect",
+            "globalSecret": "Another secret message"
+        }
+    ],
+    "username3": "",
+    "password3": "",
+    "submit": true
+}
+

--- a/tests/test_conditional_visibility_nested_json_logic.py
+++ b/tests/test_conditional_visibility_nested_json_logic.py
@@ -16,6 +16,8 @@ class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
         self.builder_json = readfile('data', 'test_conditional_visibility_nested_json_logic_builder.json')
         self.hide_secret_form_json = readfile('data', 'test_conditional_visibility_nested_json_logic_hide_secret.json')
         self.show_secret_form_json = readfile('data', 'test_conditional_visibility_nested_json_logic_show_secret.json')
+        self.hide_global_secret_only_form_json = readfile('data', 'test_conditional_visibility_nested_json_logic_hide_global_secret_only.json')
+        self.show_global_secret_only_form_json = readfile('data', 'test_conditional_visibility_nested_json_logic_show_global_secret_only.json')
 
 
     def test_conditionally_shown_top_level_form_elements_have_default_state_in_builder(self):
@@ -74,7 +76,7 @@ class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
         self.assertTrue(show_secret_form.input_components['secret2'].conditionally_visible)
 
 
-    def test_conditionally_shown_form_elements_in_data_grid_toggle_on_condition_met(self):
+    def test_conditionally_shown_form_elements_in_data_grid_toggle_on_local_row_condition_met(self):
         builder = Builder(self.builder_json)
 
         hide_secret_form = Form(self.hide_secret_form_json, builder)
@@ -84,11 +86,13 @@ class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
         self.assertTrue(hide_secret_first_row.input_components['username3'].conditionally_visible)
         self.assertTrue(hide_secret_first_row.input_components['password3'].conditionally_visible)
         self.assertFalse(hide_secret_first_row.input_components['secret3'].conditionally_visible)
+        self.assertFalse(hide_secret_first_row.input_components['globalSecret'].conditionally_visible)
 
         hide_secret_second_row = hide_secret_datagrid.rows[1]
         self.assertTrue(hide_secret_second_row.input_components['username3'].conditionally_visible)
         self.assertTrue(hide_secret_second_row.input_components['password3'].conditionally_visible)
         self.assertFalse(hide_secret_second_row.input_components['secret3'].conditionally_visible)
+        self.assertFalse(hide_secret_second_row.input_components['globalSecret'].conditionally_visible)
 
         show_secret_form = Form(self.show_secret_form_json, builder)
         show_secret_datagrid = show_secret_form.input_components['dataGrid']
@@ -97,11 +101,47 @@ class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
         self.assertTrue(show_secret_first_row.input_components['username3'].conditionally_visible)
         self.assertTrue(show_secret_first_row.input_components['password3'].conditionally_visible)
         self.assertTrue(show_secret_first_row.input_components['secret3'].conditionally_visible)
+        self.assertTrue(show_secret_first_row.input_components['globalSecret'].conditionally_visible)
 
         show_secret_second_row = show_secret_datagrid.rows[0]
         self.assertTrue(show_secret_second_row.input_components['username3'].conditionally_visible)
         self.assertTrue(show_secret_second_row.input_components['password3'].conditionally_visible)
         self.assertTrue(show_secret_second_row.input_components['secret3'].conditionally_visible)
+        self.assertTrue(show_secret_second_row.input_components['globalSecret'].conditionally_visible)
+
+
+    def test_conditionally_shown_form_elements_in_data_grid_toggle_on_global_data_condition_met(self):
+        builder = Builder(self.builder_json)
+
+        show_global_secret_only_form = Form(self.show_global_secret_only_form_json, builder)
+        show_global_secret_only_datagrid = show_global_secret_only_form.input_components['dataGrid']
+
+        show_global_secret_only_first_row = show_global_secret_only_datagrid.rows[0]
+        self.assertTrue(show_global_secret_only_first_row.input_components['username3'].conditionally_visible)
+        self.assertTrue(show_global_secret_only_first_row.input_components['password3'].conditionally_visible)
+        self.assertFalse(show_global_secret_only_first_row.input_components['secret3'].conditionally_visible)
+        self.assertTrue(show_global_secret_only_first_row.input_components['globalSecret'].conditionally_visible)
+
+        show_global_secret_only_second_row = show_global_secret_only_datagrid.rows[1]
+        self.assertTrue(show_global_secret_only_second_row.input_components['username3'].conditionally_visible)
+        self.assertTrue(show_global_secret_only_second_row.input_components['password3'].conditionally_visible)
+        self.assertFalse(show_global_secret_only_second_row.input_components['secret3'].conditionally_visible)
+        self.assertTrue(show_global_secret_only_second_row.input_components['globalSecret'].conditionally_visible)
+
+        hide_global_secret_only_form = Form(self.hide_global_secret_only_form_json, builder)
+        hide_global_secret_only_datagrid = hide_global_secret_only_form.input_components['dataGrid']
+
+        hide_global_secret_only_first_row = hide_global_secret_only_datagrid.rows[0]
+        self.assertTrue(hide_global_secret_only_first_row.input_components['username3'].conditionally_visible)
+        self.assertTrue(hide_global_secret_only_first_row.input_components['password3'].conditionally_visible)
+        self.assertTrue(hide_global_secret_only_first_row.input_components['secret3'].conditionally_visible)
+        self.assertFalse(hide_global_secret_only_first_row.input_components['globalSecret'].conditionally_visible)
+
+        hide_global_secret_only_second_row = hide_global_secret_only_datagrid.rows[0]
+        self.assertTrue(hide_global_secret_only_second_row.input_components['username3'].conditionally_visible)
+        self.assertTrue(hide_global_secret_only_second_row.input_components['password3'].conditionally_visible)
+        self.assertTrue(hide_global_secret_only_second_row.input_components['secret3'].conditionally_visible)
+        self.assertFalse(hide_global_secret_only_second_row.input_components['globalSecret'].conditionally_visible)
 
 
     def test_conditionally_shown_top_level_form_elements_do_not_render_when_hidden(self):
@@ -144,7 +184,7 @@ class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
         self.assertEqual('<p>Secret message</p>', show_secret_form.input_components['secret2'].html_component)
 
 
-    def test_conditionally_shown_form_elements_in_data_grid_do_not_render_when_hidden(self):
+    def test_conditionally_shown_form_elements_for_local_row_condition_in_data_grid_do_not_render_when_hidden(self):
         builder = Builder(self.builder_json)
 
         hide_secret_form = Form(self.hide_secret_form_json, builder)
@@ -152,16 +192,18 @@ class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
         hide_secret_datagrid = hide_secret_form.input_components['dataGrid']
 
         hide_secret_first_row = hide_secret_datagrid.rows[0]
-        self.assertEqual('<tr><td><table><tr><td><p>wrong</p></td><td><p>incorrect</p></td><td></td></tr></table></td></tr>', hide_secret_first_row.html_component)
+        self.assertEqual('<tr><td><table><tr><td><p>wrong</p></td><td><p>incorrect</p></td><td></td><td></td></tr></table></td></tr>', hide_secret_first_row.html_component)
         self.assertEqual('<p>wrong</p>', hide_secret_first_row.input_components['username3'].html_component)
         self.assertEqual('<p>incorrect</p>', hide_secret_first_row.input_components['password3'].html_component)
         self.assertEqual('', hide_secret_first_row.input_components['secret3'].html_component)
+        self.assertEqual('', hide_secret_first_row.input_components['globalSecret'].html_component)
 
         hide_secret_second_row = hide_secret_datagrid.rows[1]
-        self.assertEqual('<tr><td><table><tr><td><p>wrong</p></td><td><p>incorrect</p></td><td></td></tr></table></td></tr>', hide_secret_second_row.html_component)
+        self.assertEqual('<tr><td><table><tr><td><p>wrong</p></td><td><p>incorrect</p></td><td></td><td></td></tr></table></td></tr>', hide_secret_second_row.html_component)
         self.assertEqual('<p>wrong</p>', hide_secret_second_row.input_components['username3'].html_component)
         self.assertEqual('<p>incorrect</p>', hide_secret_second_row.input_components['password3'].html_component)
         self.assertEqual('', hide_secret_second_row.input_components['secret3'].html_component)
+        self.assertEqual('', hide_secret_second_row.input_components['globalSecret'].html_component)
 
         # Tying it all together
         self.assertEqual(
@@ -174,19 +216,73 @@ class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
         show_secret_datagrid = show_secret_form.input_components['dataGrid']
 
         show_secret_first_row = show_secret_datagrid.rows[0]
-        self.assertEqual('<tr><td><table><tr><td><p>user</p></td><td><p>secret</p></td><td><p>Secret message</p></td></tr></table></td></tr>', show_secret_first_row.html_component)
+        self.assertEqual('<tr><td><table><tr><td><p>user</p></td><td><p>secret</p></td><td><p>Secret message</p></td><td><p>Another secret message</p></td></tr></table></td></tr>', show_secret_first_row.html_component)
         self.assertEqual('<p>user</p>', show_secret_first_row.input_components['username3'].html_component)
         self.assertEqual('<p>secret</p>', show_secret_first_row.input_components['password3'].html_component)
         self.assertEqual('<p>Secret message</p>', show_secret_first_row.input_components['secret3'].html_component)
+        self.assertEqual('<p>Another secret message</p>', show_secret_first_row.input_components['globalSecret'].html_component)
 
         show_secret_second_row = show_secret_datagrid.rows[0]
-        self.assertEqual('<tr><td><table><tr><td><p>user</p></td><td><p>secret</p></td><td><p>Secret message</p></td></tr></table></td></tr>', show_secret_second_row.html_component)
+        self.assertEqual('<tr><td><table><tr><td><p>user</p></td><td><p>secret</p></td><td><p>Secret message</p></td><td><p>Another secret message</p></td></tr></table></td></tr>', show_secret_second_row.html_component)
         self.assertEqual('<p>user</p>', show_secret_second_row.input_components['username3'].html_component)
         self.assertEqual('<p>secret</p>', show_secret_second_row.input_components['password3'].html_component)
         self.assertEqual('<p>Secret message</p>', show_secret_second_row.input_components['secret3'].html_component)
+        self.assertEqual('<p>Another secret message</p>', show_secret_second_row.input_components['globalSecret'].html_component)
 
         # Tying it all together
         self.assertEqual(
             f'<table>{show_secret_first_row.html_component}{show_secret_second_row.html_component}</table>',
             show_secret_datagrid.html_component
+        )
+
+
+    def test_conditionally_shown_form_elements_for_global_data_condition_in_data_grid_do_not_render_when_hidden(self):
+        builder = Builder(self.builder_json)
+
+        show_global_secret_only_form = Form(self.show_global_secret_only_form_json, builder)
+        show_global_secret_only_form.render_components()
+        show_global_secret_only_datagrid = show_global_secret_only_form.input_components['dataGrid']
+
+        show_global_secret_only_first_row = show_global_secret_only_datagrid.rows[0]
+        self.assertEqual('<tr><td><table><tr><td><p>wrong</p></td><td><p>incorrect</p></td><td></td><td><p>Another secret message</p></td></tr></table></td></tr>', show_global_secret_only_first_row.html_component)
+        self.assertEqual('<p>wrong</p>', show_global_secret_only_first_row.input_components['username3'].html_component)
+        self.assertEqual('<p>incorrect</p>', show_global_secret_only_first_row.input_components['password3'].html_component)
+        self.assertEqual('', show_global_secret_only_first_row.input_components['secret3'].html_component)
+        self.assertEqual('<p>Another secret message</p>', show_global_secret_only_first_row.input_components['globalSecret'].html_component)
+
+        show_global_secret_only_second_row = show_global_secret_only_datagrid.rows[1]
+        self.assertEqual('<tr><td><table><tr><td><p>wrong</p></td><td><p>incorrect</p></td><td></td><td><p>Another secret message</p></td></tr></table></td></tr>', show_global_secret_only_second_row.html_component)
+        self.assertEqual('<p>wrong</p>', show_global_secret_only_second_row.input_components['username3'].html_component)
+        self.assertEqual('<p>incorrect</p>', show_global_secret_only_second_row.input_components['password3'].html_component)
+        self.assertEqual('', show_global_secret_only_second_row.input_components['secret3'].html_component)
+        self.assertEqual('<p>Another secret message</p>', show_global_secret_only_second_row.input_components['globalSecret'].html_component)
+
+        # Tying it all together
+        self.assertEqual(
+            f'<table>{show_global_secret_only_first_row.html_component}{show_global_secret_only_second_row.html_component}</table>',
+            show_global_secret_only_datagrid.html_component
+        )
+
+        hide_global_secret_only_form = Form(self.hide_global_secret_only_form_json, builder)
+        hide_global_secret_only_form.render_components()
+        hide_global_secret_only_datagrid = hide_global_secret_only_form.input_components['dataGrid']
+
+        hide_global_secret_only_first_row = hide_global_secret_only_datagrid.rows[0]
+        self.assertEqual('<tr><td><table><tr><td><p>user</p></td><td><p>secret</p></td><td><p>Secret message</p></td><td></td></tr></table></td></tr>', hide_global_secret_only_first_row.html_component)
+        self.assertEqual('<p>user</p>', hide_global_secret_only_first_row.input_components['username3'].html_component)
+        self.assertEqual('<p>secret</p>', hide_global_secret_only_first_row.input_components['password3'].html_component)
+        self.assertEqual('<p>Secret message</p>', hide_global_secret_only_first_row.input_components['secret3'].html_component)
+        self.assertEqual('', hide_global_secret_only_first_row.input_components['globalSecret'].html_component)
+
+        hide_global_secret_only_second_row = hide_global_secret_only_datagrid.rows[0]
+        self.assertEqual('<tr><td><table><tr><td><p>user</p></td><td><p>secret</p></td><td><p>Secret message</p></td><td></td></tr></table></td></tr>', hide_global_secret_only_second_row.html_component)
+        self.assertEqual('<p>user</p>', hide_global_secret_only_second_row.input_components['username3'].html_component)
+        self.assertEqual('<p>secret</p>', hide_global_secret_only_second_row.input_components['password3'].html_component)
+        self.assertEqual('<p>Secret message</p>', hide_global_secret_only_second_row.input_components['secret3'].html_component)
+        self.assertEqual('', hide_global_secret_only_second_row.input_components['globalSecret'].html_component)
+
+        # Tying it all together
+        self.assertEqual(
+            f'<table>{hide_global_secret_only_first_row.html_component}{hide_global_secret_only_second_row.html_component}</table>',
+            hide_global_secret_only_datagrid.html_component
         )


### PR DESCRIPTION
Before, conditional logic would only see the current row's data.  To
extend this, we need to pass on the full original data map to each
nested component.

Working on this exposed a potential issue: if "value" is used in the
form as a key, it will be clobbered by the current component in the
hierarchy.  This means conditional logic won't work properly if it
depends on this "value" element.

The proper fix would be to have the form property encode just the raw
JSON form and have another property for the parsed and Python-encoded
value.