### PR TITLE
Fix loading of tableComponents and correct unit tests

### DIFF
--- a/formiodata/components.py
+++ b/formiodata/components.py
@@ -858,20 +858,28 @@ class panelComponent(layoutComponentBase):
 
 
 class tableComponent(layoutComponentBase):
+    def __init__(self, raw, builder, **kwargs):
+        self.rows = []
+        super().__init__(raw, builder, **kwargs)
 
-    @property
-    def rows(self):
-        rows = []
-        for row in self.raw['rows']:
-            row_components = []
+    def load_data(self, data, load_children=True):
+        self.rows = []
 
-            for cols in row:
-                for col_comp in cols['components']:
-                    for key, comp in self.components.items():
-                        if col_comp['id'] == comp.id:
-                            row_components.append(comp)
-            rows.append(row_components)
-        return rows
+        for data_row in self.raw.get('rows', []):
+            row = []
+
+            for col in data_row:
+                components = []
+                for component in col['components']:
+                    # Only determine and load class if component type.
+                    if 'type' in component:
+                        component_obj = self.builder.get_component_object(component)
+                        component_obj.load(self.child_component_owner, parent=self, data=data, all_data=self._all_data)
+                        components.append(component_obj)
+
+                row.append({'column': col, 'components': components})
+
+            self.rows.append(row)
 
 
 class tabsComponent(layoutComponentBase):

--- a/tests/test_component_table.py
+++ b/tests/test_component_table.py
@@ -30,9 +30,16 @@ class tableComponentTestCase(ComponentTestCase):
 
     def test_get_row_labels(self):
         builder_table = self.builder.components['table']
-        table = self.form.input_components[builder_table.key]
+        table = self.form.components[builder_table.key]
 
         self.assertEqual(len(table.rows), 2)
+
+        labels = ['Text Field', 'Checkbox']
+        for row in table.rows:
+            for col in row:
+                for comp in col['components']:
+                    self.assertIn(comp.label , labels)
+
 
     def test_get_rows_values(self):
         builder_table = self.builder.components['table']
@@ -40,11 +47,14 @@ class tableComponentTestCase(ComponentTestCase):
 
         self.assertEqual(len(table.rows), 2)
 
-        textField_values = ['Elephant', 'Lion']
-        checkbox_values = [True, False]
-        for row_with_components in table.rows:
-            for component in row_with_components.input_components.values():
-                if component.type == 'textfield':
-                    self.assertIn(component.value , textField_values)
-                if component.type == 'checkbox':
-                    self.assertIn(component.value , checkbox_values)
+        # Accessing directly...
+        self.assertEqual(table.components['textField'].value, 'Elephant')
+        self.assertEqual(table.components['checkbox'].value, True)
+        self.assertEqual(table.components['textField1'].value, 'Lion')
+        self.assertEqual(table.components['checkbox1'].value, False)
+
+        # Or through rows/cols:
+        self.assertEqual(table.rows[0][0]['components'][0], table.components['textField'])
+        self.assertEqual(table.rows[0][1]['components'][0], table.components['checkbox'])
+        self.assertEqual(table.rows[1][0]['components'][0], table.components['textField1'])
+        self.assertEqual(table.rows[1][1]['components'][0], table.components['checkbox1'])


### PR DESCRIPTION
The unit tests were written like for dataGrid, but dataGrid is
"special" in that it can instantiate rows dynamically depending on the
input.  Table is more like the PanelComponent or such, which has a
predetermined set of rows and columns.  In each row/column, there will
be components with predetermined keys.

This also means we don't have to implement a getter for the rows, but
we can simply set the rows directly to the instantiated child
components when loading the data, as the structure is known by the
builder already.