### PR TITLE
Fixes so PDF reports get rendered on odoo11

### DIFF
--- a/formiodata/components.py
+++ b/formiodata/components.py
@@ -129,7 +129,7 @@ class Component:
 
     @property
     def required(self):
-        return self.raw.get('validate').get('required')
+        return self.raw.get('validate', {}).get('required')
 
     @property
     def properties(self):
@@ -759,7 +759,10 @@ class columnsComponent(layoutComponentBase):
 
             for col_comp in col['components']:
                 for key, comp in self.components.items():
-                    if col_comp['id'] == comp.id:
+                    if col_comp.get('id') and col_comp['id'] == comp.id:
+                        components.append(comp)
+
+                    elif col_comp.get('key') and col_comp['key'] == comp.key:
                         components.append(comp)
 
             if col['width'] >= 12:

--- a/formiodata/components.py
+++ b/formiodata/components.py
@@ -759,10 +759,7 @@ class columnsComponent(layoutComponentBase):
 
             for col_comp in col['components']:
                 for key, comp in self.components.items():
-                    if col_comp.get('id') and col_comp['id'] == comp.id:
-                        components.append(comp)
-
-                    elif col_comp.get('key') and col_comp['key'] == comp.key:
+                    if col_comp['id'] == comp.id:
                         components.append(comp)
 
             if col['width'] >= 12:


### PR DESCRIPTION
Hi there, 

I'm from a New Zealand company, we use formio for our clients on odoo11 & odoo14.

So there were some issues we discovered regarding printing PDF reports (available udner Print menu on formio.form objects), and I was able to fix them by the changes I've committed. 

Cheers,
Kristina