### PR TITLE
Add continuous integration support via GitHub Actions

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,48 @@
+name: Test Python-formio-data
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  test-without-json-logic:
+    name: Basic unit tests
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v3
+
+    - name: Set up Nix with direnv support
+      uses: aldoborrero/use-nix-action@v2
+      with:
+        nix_path: nixpkgs=channel:nixos-23.05
+
+    - name: Install basic dependencies via poetry
+      run: poetry install
+
+    - name: Run the tests
+      run: poetry run python -m unittest
+
+
+  test-with-json-logic:
+    name: Unit tests with json_logic
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v3
+
+    - name: Set up Nix with direnv support
+      uses: aldoborrero/use-nix-action@v2
+      with:
+        nix_path: nixpkgs=channel:nixos-23.05
+
+    - name: Install dependencies via poetry, including json_logic
+      run: poetry install -E json_logic
+
+    - name: Run the tests
+      run: poetry run python -m unittest

--- a/tests/test_conditional_visibility_json_logic.py
+++ b/tests/test_conditional_visibility_json_logic.py
@@ -4,13 +4,13 @@
 import json
 import unittest
 
-from tests.utils import readfile
+from tests.utils import readfile, ConditionalVisibilityTestHelpers
 from formiodata.builder import Builder
 from formiodata.form import Form
 from formiodata.components import textfieldComponent, passwordComponent
 
 
-class ConditionalVisibilityJsonLogicTestCase(unittest.TestCase):
+class ConditionalVisibilityJsonLogicTestCase(ConditionalVisibilityTestHelpers, unittest.TestCase):
     def setUp(self):
         super(ConditionalVisibilityJsonLogicTestCase, self).setUp()
 
@@ -22,23 +22,23 @@ class ConditionalVisibilityJsonLogicTestCase(unittest.TestCase):
     def test_conditionally_shown_form_elements_have_default_state_in_builder(self):
         builder = Builder(self.builder_json)
 
-        self.assertTrue(builder.input_components['username'].conditionally_visible)
-        self.assertTrue(builder.input_components['password'].conditionally_visible)
-        self.assertFalse(builder.input_components['secret'].conditionally_visible)
+        self.assertVisible(builder.input_components['username'])
+        self.assertVisible(builder.input_components['password'])
+        self.assertNotVisible(builder.input_components['secret'])
 
 
     def test_conditionally_shown_form_elements_toggle_on_condition_being_met(self):
         builder = Builder(self.builder_json)
 
         hide_secret_form = Form(self.hide_secret_form_json, builder)
-        self.assertTrue(hide_secret_form.input_components['username'].conditionally_visible)
-        self.assertTrue(hide_secret_form.input_components['password'].conditionally_visible)
-        self.assertFalse(hide_secret_form.input_components['secret'].conditionally_visible)
+        self.assertVisible(hide_secret_form.input_components['username'])
+        self.assertVisible(hide_secret_form.input_components['password'])
+        self.assertNotVisible(hide_secret_form.input_components['secret'])
 
         show_secret_form = Form(self.show_secret_form_json, builder)
-        self.assertTrue(show_secret_form.input_components['username'].conditionally_visible)
-        self.assertTrue(show_secret_form.input_components['password'].conditionally_visible)
-        self.assertTrue(show_secret_form.input_components['secret'].conditionally_visible)
+        self.assertVisible(show_secret_form.input_components['username'])
+        self.assertVisible(show_secret_form.input_components['password'])
+        self.assertVisible(show_secret_form.input_components['secret'])
 
 
     def test_conditionally_shown_form_elements_do_not_render_when_hidden(self):

--- a/tests/test_conditional_visibility_nested_json_logic.py
+++ b/tests/test_conditional_visibility_nested_json_logic.py
@@ -4,12 +4,12 @@
 import json
 import unittest
 
-from tests.utils import readfile
+from tests.utils import readfile, ConditionalVisibilityTestHelpers
 from formiodata.builder import Builder
 from formiodata.form import Form
 from formiodata.components import textfieldComponent, passwordComponent
 
-class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
+class ConditionalVisibilityNestedJsonLogicTestCase(ConditionalVisibilityTestHelpers, unittest.TestCase):
     def setUp(self):
         super(ConditionalVisibilityNestedJsonLogicTestCase, self).setUp()
 
@@ -23,57 +23,57 @@ class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
     def test_conditionally_shown_top_level_form_elements_have_default_state_in_builder(self):
         builder = Builder(self.builder_json)
 
-        self.assertTrue(builder.input_components['username'].conditionally_visible)
-        self.assertTrue(builder.input_components['password'].conditionally_visible)
-        self.assertFalse(builder.input_components['secret'].conditionally_visible)
+        self.assertVisible(builder.input_components['username'])
+        self.assertVisible(builder.input_components['password'])
+        self.assertNotVisible(builder.input_components['secret'])
 
 
     def test_conditionally_shown_form_elements_in_panel_have_default_state_in_builder(self):
         builder = Builder(self.builder_json)
 
-        self.assertTrue(builder.input_components['username1'].conditionally_visible)
-        self.assertTrue(builder.input_components['password1'].conditionally_visible)
-        self.assertFalse(builder.input_components['secret1'].conditionally_visible)
+        self.assertVisible(builder.input_components['username1'])
+        self.assertVisible(builder.input_components['password1'])
+        self.assertNotVisible(builder.input_components['secret1'])
 
-        self.assertTrue(builder.input_components['username2'].conditionally_visible)
-        self.assertTrue(builder.input_components['password2'].conditionally_visible)
-        self.assertFalse(builder.input_components['secret2'].conditionally_visible)
+        self.assertVisible(builder.input_components['username2'])
+        self.assertVisible(builder.input_components['password2'])
+        self.assertNotVisible(builder.input_components['secret2'])
 
 
     def test_conditionally_shown_top_level_form_elements_toggle_on_condition_being_met(self):
         builder = Builder(self.builder_json)
 
         hide_secret_form = Form(self.hide_secret_form_json, builder)
-        self.assertTrue(hide_secret_form.input_components['username'].conditionally_visible)
-        self.assertTrue(hide_secret_form.input_components['password'].conditionally_visible)
-        self.assertFalse(hide_secret_form.input_components['secret'].conditionally_visible)
+        self.assertVisible(hide_secret_form.input_components['username'])
+        self.assertVisible(hide_secret_form.input_components['password'])
+        self.assertNotVisible(hide_secret_form.input_components['secret'])
 
         show_secret_form = Form(self.show_secret_form_json, builder)
-        self.assertTrue(show_secret_form.input_components['username'].conditionally_visible)
-        self.assertTrue(show_secret_form.input_components['password'].conditionally_visible)
-        self.assertTrue(show_secret_form.input_components['secret'].conditionally_visible)
+        self.assertVisible(show_secret_form.input_components['username'])
+        self.assertVisible(show_secret_form.input_components['password'])
+        self.assertVisible(show_secret_form.input_components['secret'])
 
 
     def test_conditionally_shown_form_elements_in_panel_toggle_on_condition_being_met(self):
         builder = Builder(self.builder_json)
 
         hide_secret_form = Form(self.hide_secret_form_json, builder)
-        self.assertTrue(hide_secret_form.input_components['username1'].conditionally_visible)
-        self.assertTrue(hide_secret_form.input_components['password1'].conditionally_visible)
-        self.assertFalse(hide_secret_form.input_components['secret1'].conditionally_visible)
+        self.assertVisible(hide_secret_form.input_components['username1'])
+        self.assertVisible(hide_secret_form.input_components['password1'])
+        self.assertNotVisible(hide_secret_form.input_components['secret1'])
 
-        self.assertTrue(hide_secret_form.input_components['username2'].conditionally_visible)
-        self.assertTrue(hide_secret_form.input_components['password2'].conditionally_visible)
-        self.assertFalse(hide_secret_form.input_components['secret2'].conditionally_visible)
+        self.assertVisible(hide_secret_form.input_components['username2'])
+        self.assertVisible(hide_secret_form.input_components['password2'])
+        self.assertNotVisible(hide_secret_form.input_components['secret2'])
 
         show_secret_form = Form(self.show_secret_form_json, builder)
-        self.assertTrue(show_secret_form.input_components['username1'].conditionally_visible)
-        self.assertTrue(show_secret_form.input_components['password1'].conditionally_visible)
-        self.assertTrue(show_secret_form.input_components['secret1'].conditionally_visible)
+        self.assertVisible(show_secret_form.input_components['username1'])
+        self.assertVisible(show_secret_form.input_components['password1'])
+        self.assertVisible(show_secret_form.input_components['secret1'])
 
-        self.assertTrue(show_secret_form.input_components['username2'].conditionally_visible)
-        self.assertTrue(show_secret_form.input_components['password2'].conditionally_visible)
-        self.assertTrue(show_secret_form.input_components['secret2'].conditionally_visible)
+        self.assertVisible(show_secret_form.input_components['username2'])
+        self.assertVisible(show_secret_form.input_components['password2'])
+        self.assertVisible(show_secret_form.input_components['secret2'])
 
 
     def test_conditionally_shown_form_elements_in_data_grid_toggle_on_local_row_condition_met(self):
@@ -83,31 +83,31 @@ class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
         hide_secret_datagrid = hide_secret_form.input_components['dataGrid']
 
         hide_secret_first_row = hide_secret_datagrid.rows[0]
-        self.assertTrue(hide_secret_first_row.input_components['username3'].conditionally_visible)
-        self.assertTrue(hide_secret_first_row.input_components['password3'].conditionally_visible)
-        self.assertFalse(hide_secret_first_row.input_components['secret3'].conditionally_visible)
-        self.assertFalse(hide_secret_first_row.input_components['globalSecret'].conditionally_visible)
+        self.assertVisible(hide_secret_first_row.input_components['username3'])
+        self.assertVisible(hide_secret_first_row.input_components['password3'])
+        self.assertNotVisible(hide_secret_first_row.input_components['secret3'])
+        self.assertNotVisible(hide_secret_first_row.input_components['globalSecret'])
 
         hide_secret_second_row = hide_secret_datagrid.rows[1]
-        self.assertTrue(hide_secret_second_row.input_components['username3'].conditionally_visible)
-        self.assertTrue(hide_secret_second_row.input_components['password3'].conditionally_visible)
-        self.assertFalse(hide_secret_second_row.input_components['secret3'].conditionally_visible)
-        self.assertFalse(hide_secret_second_row.input_components['globalSecret'].conditionally_visible)
+        self.assertVisible(hide_secret_second_row.input_components['username3'])
+        self.assertVisible(hide_secret_second_row.input_components['password3'])
+        self.assertNotVisible(hide_secret_second_row.input_components['secret3'])
+        self.assertNotVisible(hide_secret_second_row.input_components['globalSecret'])
 
         show_secret_form = Form(self.show_secret_form_json, builder)
         show_secret_datagrid = show_secret_form.input_components['dataGrid']
 
         show_secret_first_row = show_secret_datagrid.rows[0]
-        self.assertTrue(show_secret_first_row.input_components['username3'].conditionally_visible)
-        self.assertTrue(show_secret_first_row.input_components['password3'].conditionally_visible)
-        self.assertTrue(show_secret_first_row.input_components['secret3'].conditionally_visible)
-        self.assertTrue(show_secret_first_row.input_components['globalSecret'].conditionally_visible)
+        self.assertVisible(show_secret_first_row.input_components['username3'])
+        self.assertVisible(show_secret_first_row.input_components['password3'])
+        self.assertVisible(show_secret_first_row.input_components['secret3'])
+        self.assertVisible(show_secret_first_row.input_components['globalSecret'])
 
         show_secret_second_row = show_secret_datagrid.rows[0]
-        self.assertTrue(show_secret_second_row.input_components['username3'].conditionally_visible)
-        self.assertTrue(show_secret_second_row.input_components['password3'].conditionally_visible)
-        self.assertTrue(show_secret_second_row.input_components['secret3'].conditionally_visible)
-        self.assertTrue(show_secret_second_row.input_components['globalSecret'].conditionally_visible)
+        self.assertVisible(show_secret_second_row.input_components['username3'])
+        self.assertVisible(show_secret_second_row.input_components['password3'])
+        self.assertVisible(show_secret_second_row.input_components['secret3'])
+        self.assertVisible(show_secret_second_row.input_components['globalSecret'])
 
 
     def test_conditionally_shown_form_elements_in_data_grid_toggle_on_global_data_condition_met(self):
@@ -117,31 +117,31 @@ class ConditionalVisibilityNestedJsonLogicTestCase(unittest.TestCase):
         show_global_secret_only_datagrid = show_global_secret_only_form.input_components['dataGrid']
 
         show_global_secret_only_first_row = show_global_secret_only_datagrid.rows[0]
-        self.assertTrue(show_global_secret_only_first_row.input_components['username3'].conditionally_visible)
-        self.assertTrue(show_global_secret_only_first_row.input_components['password3'].conditionally_visible)
-        self.assertFalse(show_global_secret_only_first_row.input_components['secret3'].conditionally_visible)
-        self.assertTrue(show_global_secret_only_first_row.input_components['globalSecret'].conditionally_visible)
+        self.assertVisible(show_global_secret_only_first_row.input_components['username3'])
+        self.assertVisible(show_global_secret_only_first_row.input_components['password3'])
+        self.assertNotVisible(show_global_secret_only_first_row.input_components['secret3'])
+        self.assertVisible(show_global_secret_only_first_row.input_components['globalSecret'])
 
         show_global_secret_only_second_row = show_global_secret_only_datagrid.rows[1]
-        self.assertTrue(show_global_secret_only_second_row.input_components['username3'].conditionally_visible)
-        self.assertTrue(show_global_secret_only_second_row.input_components['password3'].conditionally_visible)
-        self.assertFalse(show_global_secret_only_second_row.input_components['secret3'].conditionally_visible)
-        self.assertTrue(show_global_secret_only_second_row.input_components['globalSecret'].conditionally_visible)
+        self.assertVisible(show_global_secret_only_second_row.input_components['username3'])
+        self.assertVisible(show_global_secret_only_second_row.input_components['password3'])
+        self.assertNotVisible(show_global_secret_only_second_row.input_components['secret3'])
+        self.assertVisible(show_global_secret_only_second_row.input_components['globalSecret'])
 
         hide_global_secret_only_form = Form(self.hide_global_secret_only_form_json, builder)
         hide_global_secret_only_datagrid = hide_global_secret_only_form.input_components['dataGrid']
 
         hide_global_secret_only_first_row = hide_global_secret_only_datagrid.rows[0]
-        self.assertTrue(hide_global_secret_only_first_row.input_components['username3'].conditionally_visible)
-        self.assertTrue(hide_global_secret_only_first_row.input_components['password3'].conditionally_visible)
-        self.assertTrue(hide_global_secret_only_first_row.input_components['secret3'].conditionally_visible)
-        self.assertFalse(hide_global_secret_only_first_row.input_components['globalSecret'].conditionally_visible)
+        self.assertVisible(hide_global_secret_only_first_row.input_components['username3'])
+        self.assertVisible(hide_global_secret_only_first_row.input_components['password3'])
+        self.assertVisible(hide_global_secret_only_first_row.input_components['secret3'])
+        self.assertNotVisible(hide_global_secret_only_first_row.input_components['globalSecret'])
 
         hide_global_secret_only_second_row = hide_global_secret_only_datagrid.rows[0]
-        self.assertTrue(hide_global_secret_only_second_row.input_components['username3'].conditionally_visible)
-        self.assertTrue(hide_global_secret_only_second_row.input_components['password3'].conditionally_visible)
-        self.assertTrue(hide_global_secret_only_second_row.input_components['secret3'].conditionally_visible)
-        self.assertFalse(hide_global_secret_only_second_row.input_components['globalSecret'].conditionally_visible)
+        self.assertVisible(hide_global_secret_only_second_row.input_components['username3'])
+        self.assertVisible(hide_global_secret_only_second_row.input_components['password3'])
+        self.assertVisible(hide_global_secret_only_second_row.input_components['secret3'])
+        self.assertNotVisible(hide_global_secret_only_second_row.input_components['globalSecret'])
 
 
     def test_conditionally_shown_top_level_form_elements_do_not_render_when_hidden(self):

--- a/tests/test_conditional_visibility_simple.py
+++ b/tests/test_conditional_visibility_simple.py
@@ -4,13 +4,13 @@
 import json
 import unittest
 
-from tests.utils import readfile
+from tests.utils import readfile, ConditionalVisibilityTestHelpers
 from formiodata.builder import Builder
 from formiodata.form import Form
 from formiodata.components import textfieldComponent, passwordComponent
 
 
-class ConditionalVisibilitySimpleTestCase(unittest.TestCase):
+class ConditionalVisibilitySimpleTestCase(ConditionalVisibilityTestHelpers, unittest.TestCase):
     def setUp(self):
         super(ConditionalVisibilitySimpleTestCase, self).setUp()
 
@@ -22,23 +22,23 @@ class ConditionalVisibilitySimpleTestCase(unittest.TestCase):
     def test_conditionally_shown_form_elements_have_default_state_in_builder(self):
         builder = Builder(self.builder_json)
 
-        self.assertTrue(builder.input_components['textField'].conditionally_visible)
-        self.assertFalse(builder.input_components['maybeTextField'].conditionally_visible)
-        self.assertTrue(builder.input_components['maybePassword'].conditionally_visible)
+        self.assertVisible(builder.input_components['textField'])
+        self.assertNotVisible(builder.input_components['maybeTextField'])
+        self.assertVisible(builder.input_components['maybePassword'])
 
 
     def test_conditionally_shown_form_elements_toggle_on_condition_being_met(self):
         builder = Builder(self.builder_json)
 
         hide_password_form = Form(self.hide_password_form_json, builder)
-        self.assertTrue(hide_password_form.input_components['textField'].conditionally_visible)
-        self.assertFalse(hide_password_form.input_components['maybeTextField'].conditionally_visible)
-        self.assertFalse(hide_password_form.input_components['maybePassword'].conditionally_visible)
+        self.assertVisible(hide_password_form.input_components['textField'])
+        self.assertNotVisible(hide_password_form.input_components['maybeTextField'])
+        self.assertNotVisible(hide_password_form.input_components['maybePassword'])
 
         show_textfield_form = Form(self.show_textfield_form_json, builder)
-        self.assertTrue(show_textfield_form.input_components['textField'].conditionally_visible)
-        self.assertTrue(show_textfield_form.input_components['maybeTextField'].conditionally_visible)
-        self.assertTrue(show_textfield_form.input_components['maybePassword'].conditionally_visible)
+        self.assertVisible(show_textfield_form.input_components['textField'])
+        self.assertVisible(show_textfield_form.input_components['maybeTextField'])
+        self.assertVisible(show_textfield_form.input_components['maybePassword'])
 
 
     def test_conditionally_shown_form_elements_do_not_render_when_hidden(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,3 +16,24 @@ def log_unittest(unittest_obj, msg, log_level='info'):
         log += ' -- %s' % unittest_obj.shortDescription()
     log += ' - %s' % msg
     getattr(logging, log_level)(log)
+
+
+class ConditionalVisibilityTestHelpers:
+    def setUp(self):
+        super(ConditionalVisibilityTestHelpers, self).setUp()
+        try:
+            from json_logic import jsonLogic
+            self._have_json_logic = True
+        except ImportError:
+            self._have_json_logic = False
+
+    def assertVisible(self, component):
+        self.assertTrue(component.conditionally_visible)
+
+    def assertNotVisible(self, component):
+        if component.raw['conditional'].get('json') and not self._have_json_logic:
+            # Without json_logic, all components with json conditionals
+            # are considered always visible
+            self.assertTrue(component.conditionally_visible)
+        else:
+            self.assertFalse(component.conditionally_visible)


### PR DESCRIPTION
This adds GitHub Actions workflows for testing the project.  It will automatically run the tests on push.

I added actions both for testing with the optional `json_logic` extension, and without it. To make the tests work once again without `json_logic`, I've added a second commit to refactor the conditional visibility tests to use a new mixin which checks for visibility, but assumes visibility is `True` when the visibility is determined by json, and the `json_logic` dependency is missing.