### PR TITLE
Add component_class_mapping feature (argument) for the Builder instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.2.0
+
+New "component class mapping feature" for the Builder instantiation:\
+Map a custom component type to an implemented component class, which is then loaded.
+
+An example is available in the unittests of file: `tests/test_component_class_mapping.py`
+
+Also refactored the Builder constructor, from some `kwargs` to keyword arguments.
+
 ## 1.1.0
 
 Put component classes as files in the new `components` directory.\

--- a/README.md
+++ b/README.md
@@ -209,6 +209,32 @@ Datetime: datetime.datetime(2021, 5, 8, 11, 41, 5, 919943), Fahrenheit: 131
   {'firstName': <textfieldComponent>, 'lastName: <textfieldComponent>}, 
   {'email': <emailComponent>, 'companyName: <textfieldComponent>}
 ]
+
+##########################
+# components class mapping
+##########################
+
+# Below an example which verbosely shows the feature:
+# - First set a custom component type 'custom_editgrid' in the Builder JSON schema.
+# - Check (assert) whether the component object is an instance of the mapped editgridComponent.
+# This code is also present in the unittest (file): tests/test_component_class_mapping.py
+
+schema_dict = json.loads(self.builder_json)
+
+# change 'editgrid' type to 'custom_editgrid'
+for comp in schema_dict['components']:
+    if comp['key'] == 'editGrid':
+        comp['type'] = 'custom_editgrid'
+
+component_class_mapping = {'custom_editgrid': editgridComponent}
+builder = Builder(
+    schema_json,
+    component_class_mapping=component_class_mapping,
+)
+
+custom_editgrid = builder.components['editGrid']
+self.assertIsInstance(custom_editgrid, editgridComponent)
+self.assertEqual(custom_editgrid.type, 'custom_editgrid')
 ```
 
 ## Unit tests

--- a/formiodata/form.py
+++ b/formiodata/form.py
@@ -12,11 +12,13 @@ from formiodata.builder import Builder
 
 class Form:
 
-    def __init__(self, form_json, builder=None, builder_schema_json=None, lang='en', **kwargs):
+    def __init__(
+        self, form_json, builder=None, builder_schema_json=None, lang="en", **kwargs
+    ):
         """
         @param form_json
         @param builder Builder
-        @param builder_schema
+        @param builder_schema_json
         @param lang
         """
         if isinstance(form_json, dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "formio-data"
-version = "1.1.0"
+version = "1.2.0"
 homepage = "https://github.com/novacode-nl/python-formio-data"
 description = "formio.js JSON-data API"
 readme = "README.md"

--- a/tests/test_component_class_mapping.py
+++ b/tests/test_component_class_mapping.py
@@ -1,0 +1,41 @@
+# Copyright Nova Code (http://www.novacode.nl)
+# See LICENSE file for full licensing details.
+
+import json
+
+from test_common import CommonTestCase
+from formiodata.builder import Builder
+from formiodata.components.editgrid import editgridComponent
+
+
+class ComponentClassMappingTestCase(CommonTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        schema_dict = json.loads(self.builder_json)
+        for comp in schema_dict['components']:
+            if comp['key'] == 'editGrid':
+                comp['type'] = 'custom_editgrid'
+
+        self.schema_json_component_class_mapping = json.dumps(schema_dict)
+
+    def test_component_class_mapping_with_class(self):
+        component_class_mapping = {'custom_editgrid': editgridComponent}
+        builder = Builder(
+            self.schema_json_component_class_mapping,
+            component_class_mapping=component_class_mapping,
+        )
+        custom_editgrid = builder.components['editGrid']
+        self.assertIsInstance(custom_editgrid, editgridComponent)
+        self.assertEqual(custom_editgrid.type, 'custom_editgrid')
+
+    def test_component_class_mapping_with_string(self):
+        component_class_mapping = {'custom_editgrid': 'editgrid'}
+        builder = Builder(
+            self.schema_json_component_class_mapping,
+            component_class_mapping=component_class_mapping,
+        )
+        custom_editgrid = builder.components['editGrid']
+        self.assertIsInstance(custom_editgrid, editgridComponent)
+        self.assertEqual(custom_editgrid.type, 'custom_editgrid')


### PR DESCRIPTION
Map a custom component type to an implemented component class, which is then loaded.

Example, also added in README and unitest:

component_class_mapping = {'custom_editgrid': editgridComponent} builder = Builder(
    schema_json,
    component_class_mapping=component_class_mapping,
)

Also refactored the Builder constructor, from some `kwargs` to keyword arguments.