### PR TITLE
Fix get_component_object (Builder) method to handle ModuleNotFoundError.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.1
+
+Fix `get_component_object` (Builder) method to handle `ModuleNotFoundError`.\
+Therefor implemented the `get_component_class` method to determine the class with a fallback to the base `Component` class.
+
 ## 1.2.0
 
 New "component class mapping feature" for the Builder instantiation:\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "formio-data"
-version = "1.2.0"
+version = "1.2.1"
 homepage = "https://github.com/novacode-nl/python-formio-data"
 description = "formio.js JSON-data API"
 readme = "README.md"


### PR DESCRIPTION
Therefor implemented the get_component_class method to determine the class with a fallback to the base `Component` class.