### PR TITLE
Improve panelComponent label property to return the panel title instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.7
+
+Improve `panelComponent` `label` property to return the panel `title` instead.\
+This is actually more correct, because the `label` property is not visible in the form (and builder) for a panel component, but the `title` property is.
+
 ## 2.1.6
 
 Fixes:

--- a/formiodata/components/panel.py
+++ b/formiodata/components/panel.py
@@ -20,6 +20,10 @@ class panelComponent(layoutComponentBase):
                 )
 
     @property
+    def label(self):
+        return self.title
+
+    @property
     def title(self):
         title = self.raw.get('title')
         if not title:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "formio-data"
-version = "2.1.6"
+version = "2.1.7"
 homepage = "https://github.com/novacode-nl/python-formio-data"
 description = "formio.js JSON-data API"
 readme = "README.md"

--- a/tests/test_component_panel.py
+++ b/tests/test_component_panel.py
@@ -26,7 +26,7 @@ class panelComponentTestCase(ComponentTestCase):
 
     def test_get_label(self):
         panel = self.builder.components['panel']
-        self.assertEqual(panel.label, 'Panel')
+        self.assertEqual(panel.label, 'My Favourites')
 
     def test_get_title(self):
         panel = self.builder.components['panel']
@@ -35,4 +35,5 @@ class panelComponentTestCase(ComponentTestCase):
     # i18n translations
     def test_get_title_i18n_nl(self):
         panel = self.builder_i18n_nl.components['panel']
+        self.assertEqual(panel.label, 'Mijn favorieten')
         self.assertEqual(panel.title, 'Mijn favorieten')

--- a/tests/test_nested_components.py
+++ b/tests/test_nested_components.py
@@ -131,7 +131,7 @@ class NestedTestCase(unittest.TestCase):
 
         # paths
         self.assertEqual(panel.builder_path_key, ['panel'])
-        self.assertEqual(panel.builder_path_label, ['Panel'])
+        self.assertEqual(panel.builder_path_label, ['My Favourites'])
         self.assertEqual(panel.builder_input_path_key, [])
         self.assertEqual(panel.builder_input_path_label, [])
 


### PR DESCRIPTION
This is actually more correct, because the label property is not visible in the form (and builder) for a panel component, but the title property is.